### PR TITLE
Added presentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Visual Select — a DatoCMS Plugin
+
 Elegantly visualize a group of options in the DatoCMS Editor using colors, images, and more.
 
 ![](https://user-images.githubusercontent.com/56568247/155078720-2736183f-424f-4fa2-a049-c8050566e335.jpg)
@@ -6,6 +7,7 @@ Elegantly visualize a group of options in the DatoCMS Editor using colors, image
 ---
 
 ## Configuration
+
 This plugin is designed to be used on a per-field basis. To get started, add a single-string text field to any model or block, and under the presentation tab change the field editor from "Text input" to "Visual Select".
 
 ![](https://user-images.githubusercontent.com/56568247/155075251-dca1b09a-afa3-4293-ba49-aadc41702206.png)
@@ -18,19 +20,31 @@ To understand the behaviour of `extends`, see the [Global Presets](#global-prese
 
 `options` represents each visual option displayed to the editor, as well the underlying value returned by the API. There are 4 required fields on each option:
 
-| Key | Value | Description |
-| --- | --- | --- |
-| `name` | `string` | The label displayed in the editor |
-| `type` | `string` | The visualization type, see table below |
+| Key       | Value    | Description                                      |
+| --------- | -------- | ------------------------------------------------ |
+| `name`    | `string` | The label displayed in the editor                |
+| `type`    | `string` | The visualization type, see table below          |
 | `display` | `string` | The visualization display value, see table below |
-| `value` | `string` | The value returned by the API |
+| `value`   | `string` | The value returned by the API                    |
 
 #### Visualization displays
 
-| Type | Display | Example |
-| --- | --- | --- |
-| `color` | `hex` | `#bada55` |
-| `image` | `url` | `https://example.com/my-icon.svg` |
+| Type    | Display | Example                           |
+| ------- | ------- | --------------------------------- |
+| `color` | `hex`   | `#bada55`                         |
+| `image` | `url`   | `https://example.com/my-icon.svg` |
+
+### Visualization
+
+There is also a third optional field you can add called `presentation`
+
+`presentation` Is an object representing how the options should be displayed. It has 3 optional fields:
+
+| Key       | Value     | Description                                                                  |
+| --------- | --------- | ---------------------------------------------------------------------------- |
+| `type`    | `string`  | The presentation type, can be `grid` or `carousel`                           |
+| `columns` | `integer` | The number of columns, used only if the type `grid` was selected             |
+| `width`   | `string`  | The width of each option item, used only if the type `carousel` was selected |
 
 ### Example configuration
 
@@ -90,7 +104,7 @@ and then in an individual field's configuration object, use the `extends` key:
 
 ```json
 {
-    "extends": ["brandColors"]
+	"extends": ["brandColors"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There is also a third optional field you can add called `presentation`
 
 | Key       | Value     | Description                                                                  |
 | --------- | --------- | ---------------------------------------------------------------------------- |
-| `type`    | `string`  | The presentation type, can be `grid` or `carousel`                           |
+| `type`    | `string`  | The presentation type, can be either `grid` or `carousel`                           |
 | `columns` | `integer` | The number of columns, used only if the type `grid` was selected             |
 | `width`   | `string`  | The width of each option item, used only if the type `carousel` was selected |
 
@@ -63,7 +63,11 @@ There is also a third optional field you can add called `presentation`
 			"display": "#fcba03",
 			"value": "text-brand-yellow"
 		}
-	]
+	],
+	"presentation": {
+		"type": "carousel",
+		"width": "300px"
+	}
 }
 ```
 

--- a/src/entrypoints/visual-select.tsx
+++ b/src/entrypoints/visual-select.tsx
@@ -67,7 +67,7 @@ const VisualSelect = ({ctx}: VisualSelectProps): JSX.Element => {
 		return {
 			display: presentation.type === 'carousel' ? 'flex' : defaults.display,
 			gridTemplateColumns: `repeat(${
-				presentation.columns ?? defaults.columns
+				presentation.columns ?? defaults.columns as number
 			}, 1fr)`,
 		};
 	}, [presentation]);

--- a/src/entrypoints/visual-select.tsx
+++ b/src/entrypoints/visual-select.tsx
@@ -1,41 +1,93 @@
-import {useCallback, useMemo} from 'react';
-import type {ChangeEvent} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
+import type {CSSProperties, ChangeEvent} from 'react';
 import {Canvas} from 'datocms-react-ui';
 import type {RenderFieldExtensionCtx} from 'datocms-plugin-sdk';
 import get from 'lodash-es/get';
 import type {Collection, Option} from '../lib/types';
 import s from '../lib/styles.module.css';
 import {EMPTY_LENGTH} from '../constants';
-import lang, {EN_NO_VALUE_MATCH, EN_PLEASE_SELECT_OPTION, EN_NO_OPTIONS} from '../lang';
+import lang, {
+	EN_NO_VALUE_MATCH,
+	EN_PLEASE_SELECT_OPTION,
+	EN_NO_OPTIONS,
+} from '../lang';
 import Visualizer from '../components/visualizers/visualizer';
 
 type VisualSelectProps = {
 	ctx: RenderFieldExtensionCtx;
 };
 
+const defaults: CSSProperties = {
+	display: 'grid',
+	columns: 6,
+	width: '250px',
+};
+
 const VisualSelect = ({ctx}: VisualSelectProps): JSX.Element => {
-	const options = useMemo(() => {
+	const selectedField = useRef<HTMLInputElement>(null);
+
+	const [options, presentation] = useMemo(() => {
 		let allPresets: Record<string, Option[]> = {};
 
 		if (ctx.plugin.attributes.parameters.presets !== undefined) {
-			allPresets = JSON.parse(ctx.plugin.attributes.parameters.presets as string) as Record<string, Option[]>;
+			allPresets = JSON.parse(
+				ctx.plugin.attributes.parameters.presets as string,
+			) as Record<string, Option[]>;
 		}
 
-		const collection = JSON.parse(ctx.parameters.collection as string) as Collection;
-		const presetOptions = (collection.extends ?? []).flatMap(key => allPresets[key]);
+		const collection = JSON.parse(
+			ctx.parameters.collection as string,
+		) as Collection;
+		const presetOptions = (collection.extends ?? []).flatMap(
+			(key) => allPresets[key],
+		);
 
-		return [...presetOptions, ...collection.options ?? []];
+		return [
+			[...presetOptions, ...collection.options ?? []],
+			collection.presentation ?? {},
+		];
 	}, [ctx.parameters.collection, ctx.plugin.attributes.parameters.presets]);
 
-	const currentValue = useMemo(() => get(ctx.formValues, ctx.fieldPath) as string, [ctx.formValues, ctx.fieldPath]);
+	const currentValue = useMemo(
+		() => get(ctx.formValues, ctx.fieldPath) as string,
+		[ctx.formValues, ctx.fieldPath],
+	);
 
 	const hasValidValue = useMemo(() => {
-		return [...options, {value: null}].map(option => option.value).includes(currentValue);
+		return [...options, {value: null}]
+			.map((option) => option.value)
+			.includes(currentValue);
 	}, [options, currentValue]);
 
 	const handleOnChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
 		ctx.setFieldValue(ctx.fieldPath, event.target.value);
 	}, []);
+
+	const customStyle: CSSProperties = useMemo(() => {
+		return {
+			display: presentation.type === 'carousel' ? 'flex' : defaults.display,
+			gridTemplateColumns: `repeat(${
+				presentation.columns ?? defaults.columns
+			}, 1fr)`,
+		};
+	}, [presentation]);
+
+	const customWidth: CSSProperties = useMemo(() => {
+		return presentation.type === 'carousel'
+			? {width: presentation.width ?? defaults.width}
+			: {};
+	}, [presentation]);
+
+	useEffect(() => {
+		if (presentation.type === 'carousel') {
+			if (selectedField.current) {
+				selectedField.current.scrollIntoView({
+					block: 'nearest',
+					inline: 'center',
+				});
+			}
+		}
+	}, [selectedField]);
 
 	return (
 		<Canvas ctx={ctx}>
@@ -48,29 +100,49 @@ const VisualSelect = ({ctx}: VisualSelectProps): JSX.Element => {
 				</div>
 			)}
 			{options.length === EMPTY_LENGTH && (
-				<div className={s['notice']}>
-					{lang(EN_NO_OPTIONS)}
-				</div>
+				<div className={s['notice']}>{lang(EN_NO_OPTIONS)}</div>
 			)}
-			<fieldset id={ctx.field.id} className={s['fieldset']}>
-				{options.map(option => (
-					<label key={option.name} className={s['label']} htmlFor={`${option.name}_${ctx.field.id}`}>
-						<input
-							id={`${option.name}_${ctx.field.id}`}
-							className={s['radio']}
-							type="radio"
-							value={option.value}
-							name="options"
-							defaultChecked={currentValue == option.value}
-							onChange={handleOnChange}
-						/>
-						<div className={s['mark']}>
-							<Visualizer type={option.type} name={option.name} display={option.display}/>
-							<span className={s['name']}>{option.name}</span>
-						</div>
-					</label>
-				))}
-			</fieldset>
+			<div
+				className={
+					presentation.type === 'carousel' ? s['carousel-scroll-container'] : ''
+				}
+			>
+				<fieldset
+					style={customStyle}
+					id={ctx.field.id}
+					className={s['fieldset']}
+				>
+					{options.map((option) => (
+						<label
+							key={option.name}
+							className={s['label']}
+							htmlFor={`${option.name}_${ctx.field.id}`}
+						>
+							<input
+								id={`${option.name}_${ctx.field.id}`}
+								className={s['radio']}
+								type="radio"
+								value={option.value}
+								name="options"
+								defaultChecked={currentValue == option.value}
+								onChange={handleOnChange}
+							/>
+							<div
+								ref={currentValue == option.value ? selectedField : null}
+								style={customWidth}
+								className={s['mark']}
+							>
+								<Visualizer
+									type={option.type}
+									name={option.name}
+									display={option.display}
+								/>
+								<span className={s['name']}>{option.name}</span>
+							</div>
+						</label>
+					))}
+				</fieldset>
+			</div>
 		</Canvas>
 	);
 };

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -2,7 +2,8 @@
 import {keys} from 'remeda';
 import {EMPTY_LENGTH} from './constants';
 
-const EN_NO_VALUE_MATCH = 'It appears that the current value of this field ("::value") does not match any of the available options.';
+const EN_NO_VALUE_MATCH =
+	'It appears that the current value of this field ("::value") does not match any of the available options.';
 const EN_PLEASE_SELECT_OPTION = 'Please select another option below.';
 const EN_VALID_CONFIG = 'Valid configuration detected';
 const EN_JSON_PARSE_ERROR = 'Could not parse JSON data';
@@ -15,16 +16,24 @@ const EN_CHANGELOG = 'Changelog';
 const EN_SAVE_SETTINGS = 'Save settings';
 const EN_VIEW_DOCUMENTATION = 'View Documentation';
 const EN_FIELD_CONFIGURATION = 'Field Configuration';
-const EN_OPTION_MISSING_FIELD = 'Option at position ::index is missing the "::field" field';
-const EN_OPTION_NON_STRING_FIELD = 'Option at position ::index has a non-string "::field" field';
-const EN_OPTION_INVALID_TYPE = 'Option at position ::index has an invalid type "::type"';
+const EN_OPTION_MISSING_FIELD =
+	'Option at position ::index is missing the "::field" field';
+const EN_OPTION_NON_STRING_FIELD =
+	'Option at position ::index has a non-string "::field" field';
+const EN_OPTION_INVALID_TYPE =
+	'Option at position ::index has an invalid type "::type"';
 const EN_OPTION_DATA_NOT_OBJECT = 'Option at position ::index is not an object';
 const EN_PRESET_NOT_ARRAY = 'Preset at position ::index is not an array';
 const EN_DATA_NOT_OBJECT = '::field data is not an object';
 const EN_FIELD_IS_NOT_ARRAY = '"::field" is not an array';
 const EN_FIELD_IS_NOT_STRING_ARRAY = '"::field" is not an array of strings';
+const EN_PRESET_IS_NOT_OBJECT = 'Preset is not an object';
+const EN_INVALID_PRESENTATION_PARAMETERS = 'The presentation contains invalid parameters';
 
-const lang = (template: string, tokens: Record<string, string> = {}): string => {
+const lang = (
+	template: string,
+	tokens: Record<string, string> = {},
+): string => {
 	const tokenKeys = keys(tokens);
 
 	if (tokenKeys.length === EMPTY_LENGTH) {
@@ -41,6 +50,8 @@ const lang = (template: string, tokens: Record<string, string> = {}): string => 
 export default lang;
 
 export {
+	EN_PRESET_IS_NOT_OBJECT,
+	EN_INVALID_PRESENTATION_PARAMETERS,
 	EN_NO_VALUE_MATCH,
 	EN_PLEASE_SELECT_OPTION,
 	EN_VALID_CONFIG,

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -27,7 +27,7 @@ const EN_PRESET_NOT_ARRAY = 'Preset at position ::index is not an array';
 const EN_DATA_NOT_OBJECT = '::field data is not an object';
 const EN_FIELD_IS_NOT_ARRAY = '"::field" is not an array';
 const EN_FIELD_IS_NOT_STRING_ARRAY = '"::field" is not an array of strings';
-const EN_PRESET_IS_NOT_OBJECT = 'Preset is not an object';
+const EN_PRESENTTION_IS_NOT_OBJECT = 'Presentation is not an object';
 const EN_INVALID_PRESENTATION_PARAMETERS = 'The presentation contains invalid parameters';
 
 const lang = (
@@ -50,7 +50,7 @@ const lang = (
 export default lang;
 
 export {
-	EN_PRESET_IS_NOT_OBJECT,
+	EN_PRESENTTION_IS_NOT_OBJECT,
 	EN_INVALID_PRESENTATION_PARAMETERS,
 	EN_NO_VALUE_MATCH,
 	EN_PLEASE_SELECT_OPTION,

--- a/src/lib/styles.module.css
+++ b/src/lib/styles.module.css
@@ -72,7 +72,7 @@
 .image-preview-container {
 	background: var(--light-bg-color);
 	border-radius: 3px;
-	padding-top: 100%;
+	padding-top: 75%;
 	position: relative;
 }
 
@@ -180,6 +180,7 @@
 
 .preset-help-link {
 	margin-left: var(--spacing-m);
+	color: var(--base-body-color);
 }
 
 .presets-config-form {
@@ -195,4 +196,22 @@
 	border-style: solid;
 	border-width: 1px;
 	border-color: var(--warning-color);
+}
+
+.carousel-scroll-container {
+	overflow-x: scroll;
+	white-space: nowrap;
+	padding-bottom: 1rem;
+}
+
+.scroll-container {
+	overflow-x: scroll;
+	white-space: nowrap;
+}
+
+@media screen and (max-width: 600px) {
+	.preset-help {
+		flex-direction: column;
+		gap: 0.5rem;
+	}
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,11 +1,9 @@
 type VisualizationType = 'color' | 'image';
 
-type Result = {
-	type: 'error';
-	message: string;
-} | {
-	type: 'success';
-};
+type Result =
+	| {type: 'error';
+			message: string; }
+	| {type: 'success'};
 
 type Option = {
 	name: string;
@@ -14,14 +12,16 @@ type Option = {
 	value: string;
 };
 
+type Presentation = {
+	type?: 'carousel' | 'grid';
+	width?: string;
+	columns?: number;
+};
+
 type Collection = {
 	extends?: string[];
 	options?: Option[];
+	presentation?: Presentation;
 };
 
-export type {
-	Result,
-	VisualizationType,
-	Option,
-	Collection,
-};
+export type {Result, VisualizationType, Option, Collection};

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -8,8 +8,8 @@ import lang, {
 	EN_OPTION_NON_STRING_FIELD,
 	EN_PRESET_NOT_ARRAY,
 	EN_OPTION_DATA_NOT_OBJECT,
-	EN_PRESET_IS_NOT_OBJECT,
 	EN_INVALID_PRESENTATION_PARAMETERS,
+	EN_PRESENTTION_IS_NOT_OBJECT,
 } from '../lang';
 import type {Result} from './types';
 
@@ -122,13 +122,13 @@ const validateFieldConfig = (data: unknown): Result => {
 		}
 	}
 
-	if (data.presentation !== undefined && !isObject(data.options)) {
-		return error(lang(EN_PRESET_IS_NOT_OBJECT));
+	if (data.presentation !== undefined && !isObject(data.presentation)) {
+		return error(lang(EN_PRESENTTION_IS_NOT_OBJECT));
 	}
 
 	if (
 		data.presentation !== undefined &&
-		Object.keys(data.present as object).every((key) =>
+		!Object.keys(data.presentation as object).every((key) =>
 			VALID_PRESENTATION_KEYS.includes(key),
 		)
 	) {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,14 +1,21 @@
 import {isArray, isObject, isString, keys} from 'remeda';
 import lang, {
-	EN_DATA_NOT_OBJECT, EN_FIELD_IS_NOT_ARRAY,
-	EN_FIELD_IS_NOT_STRING_ARRAY, EN_OPTION_INVALID_TYPE,
-	EN_OPTION_MISSING_FIELD, EN_OPTION_NON_STRING_FIELD,
-	EN_PRESET_NOT_ARRAY, EN_OPTION_DATA_NOT_OBJECT,
+	EN_DATA_NOT_OBJECT,
+	EN_FIELD_IS_NOT_ARRAY,
+	EN_FIELD_IS_NOT_STRING_ARRAY,
+	EN_OPTION_INVALID_TYPE,
+	EN_OPTION_MISSING_FIELD,
+	EN_OPTION_NON_STRING_FIELD,
+	EN_PRESET_NOT_ARRAY,
+	EN_OPTION_DATA_NOT_OBJECT,
+	EN_PRESET_IS_NOT_OBJECT,
+	EN_INVALID_PRESENTATION_PARAMETERS,
 } from '../lang';
 import type {Result} from './types';
 
 const VALID_OPTION_KEYS = ['name', 'type', 'display', 'value'];
 const VALID_OPTION_TYPES = ['color', 'image'];
+const VALID_PRESENTATION_KEYS = ['type', 'columns', 'width'];
 
 const error = (message: string): Result => ({
 	type: 'error',
@@ -24,16 +31,28 @@ const validateOption = (data: unknown, index: number): Result => {
 		const value = data[VALID_OPTION_KEYS[i]];
 
 		if (value === undefined) {
-			return error(lang(EN_OPTION_MISSING_FIELD, {index: `${index}`, field: VALID_OPTION_KEYS[i]}));
+			return error(
+				lang(EN_OPTION_MISSING_FIELD, {
+					index: `${index}`,
+					field: VALID_OPTION_KEYS[i],
+				}),
+			);
 		}
 
 		if (!isString(value)) {
-			return error(lang(EN_OPTION_NON_STRING_FIELD, {index: `${index}`, field: VALID_OPTION_KEYS[i]}));
+			return error(
+				lang(EN_OPTION_NON_STRING_FIELD, {
+					index: `${index}`,
+					field: VALID_OPTION_KEYS[i],
+				}),
+			);
 		}
 	}
 
 	if (isString(data.type) && !VALID_OPTION_TYPES.includes(data.type)) {
-		return error(lang(EN_OPTION_INVALID_TYPE, {index: `${index}`, type: data.type}));
+		return error(
+			lang(EN_OPTION_INVALID_TYPE, {index: `${index}`, type: data.type}),
+		);
 	}
 
 	return {
@@ -80,7 +99,11 @@ const validateFieldConfig = (data: unknown): Result => {
 		return error(lang(EN_FIELD_IS_NOT_ARRAY, {field: 'Extends'}));
 	}
 
-	if (data.extends !== undefined && isArray(data.extends) && !data.extends.every(isString)) {
+	if (
+		data.extends !== undefined &&
+		isArray(data.extends) &&
+		!data.extends.every(isString)
+	) {
 		return error(lang(EN_FIELD_IS_NOT_STRING_ARRAY, {field: 'Extends'}));
 	}
 
@@ -99,13 +122,22 @@ const validateFieldConfig = (data: unknown): Result => {
 		}
 	}
 
+	if (data.presentation !== undefined && !isObject(data.options)) {
+		return error(lang(EN_PRESET_IS_NOT_OBJECT));
+	}
+
+	if (
+		data.presentation !== undefined &&
+		Object.keys(data.present as object).every((key) =>
+			VALID_PRESENTATION_KEYS.includes(key),
+		)
+	) {
+		return error(lang(EN_INVALID_PRESENTATION_PARAMETERS));
+	}
+
 	return {
 		type: 'success',
 	};
 };
 
-export {
-	validatePresetsConfig,
-	validateOption,
-	validateFieldConfig,
-};
+export {validatePresetsConfig, validateOption, validateFieldConfig};


### PR DESCRIPTION
As mentioned in #3 this  PR allows you to create a configurable "presentation" object on presets, where you can configure the display mode for the options.  This is further explained in the also updated readme :)

Although this does change the default schema for the global presets JSON and for the field configuration JSON, it also has an onBoot procedure to normalize old configuration JSONs to the new schema for all fields and for the global presets, this way we can ensure retro compatibility for current users updating to the new plugin version

Let me know what you think!